### PR TITLE
Hardware Set Model

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -15,7 +15,9 @@ def create_app(config_class=Config):
 
     from api.routes.main import main
     from api.routes.users import users
+    from api.routes.hardware import hardware
     app.register_blueprint(main)
     app.register_blueprint(users, url_prefix='/users')
+    app.register_blueprint(hardware, url_prefix='/hardware')
 
     return app

--- a/server/api/routes/hardware.py
+++ b/server/api/routes/hardware.py
@@ -1,0 +1,10 @@
+from flask import Blueprint
+from database.models import HardwareSet
+
+hardware = Blueprint('hardware', __name__)
+
+
+@hardware.route('/test', methods=['POST'])
+def hardware_test():
+    new_set = HardwareSet(capacity=200, available=100).save()
+    return new_set.to_json(), 201

--- a/server/database/__init__.py
+++ b/server/database/__init__.py
@@ -1,3 +1,3 @@
-from .models import User, db
+from .models import User, HardwareSet, db
 
-__all__ = ["db", "User"]
+__all__ = ["db", "User", "HardwareSet"]

--- a/server/database/models.py
+++ b/server/database/models.py
@@ -18,3 +18,13 @@ class User(db.Document):
     last_name = db.StringField(required=True)
     email = db.EmailField(required=True, unique=True)
     password = db.StringField(required=True)
+
+class HardwareSet(db.Document):
+    """Hardware Set for checkout
+
+    Fields:
+        capacity: hardware set capacity (how many we own)
+        available: hardware set availability (how many are not currently checked out)
+    """
+    capacity = db.IntField(required=True)
+    available = db.IntField(required=True)


### PR DESCRIPTION
### Problem
We had no database model to contain the information about the hardware sets we need to offer to our customers.

### Solution
Create a class using Mongoengine to contain hardware set data. Currently, it holds the capacity and availability data. In the future, we can add more fields if necessary. 

### Testing
I created a test route under the `hardware` url prefix to test creation. I was able to successfully create hardware sets using this route that then showed up in Mongo Express. 

Closes #31 