### PR TITLE
Wrong Password Message

### DIFF
--- a/server/api/routes/users.py
+++ b/server/api/routes/users.py
@@ -33,7 +33,7 @@ def login():
     if user.password != req['password']:
         return {
             'email': '',
-            'password': 'An account was found but the password is incorrect.'
+            'password': 'Password is incorrect.'
         }, 401
     
     access_token = create_access_token(identity=user)

--- a/server/api/routes/users.py
+++ b/server/api/routes/users.py
@@ -32,8 +32,8 @@ def login():
         }, 404
     if user.password != req['password']:
         return {
-            'email': 'An account was found but the password is incorrect.',
-            'password': ''
+            'email': '',
+            'password': 'An account was found but the password is incorrect.'
         }, 401
     
     access_token = create_access_token(identity=user)


### PR DESCRIPTION
### Problem
If the login password was incorrect, the response was sent as an email error instead of a password one.

### Solution
Move the response message to the password key instead of the email one.

### Testing
Sent a request of this kind via Postman and saw that the response was under the password section.