### PR TITLE
Hardware Set CRUD

### DIFF
--- a/server/api/routes/hardware.py
+++ b/server/api/routes/hardware.py
@@ -1,10 +1,63 @@
-from flask import Blueprint
+from flask import Blueprint, request
+from flask_jwt_extended import jwt_required
 from database.models import HardwareSet
 
 hardware = Blueprint('hardware', __name__)
 
 
-@hardware.route('/test', methods=['POST'])
-def hardware_test():
-    new_set = HardwareSet(capacity=200, available=100).save()
-    return new_set.to_json(), 201
+@hardware.route('/', methods=['POST'])
+@jwt_required()
+def hardware_create():
+    """POST hardware/
+
+    Desc: Creates a new hardware set
+
+    Returns:
+        201: newly created hardware set
+    """
+    req = request.get_json()
+    new_hardware_set = HardwareSet(**req).save()
+    return new_hardware_set.to_json(), 201
+
+
+@hardware.route('/', methods=['GET'])
+@jwt_required()
+def hardware_read():
+    """GET hardware/
+
+    Desc: Gets all available hardware sets
+
+    Returns:
+        200: all hardware sets in the database
+    """
+    return HardwareSet.objects.to_json(), 200
+
+
+@hardware.route('/<id>', methods=['PUT'])
+@jwt_required()
+def hardware_update(id):
+    """PUT hardware/<id>
+
+    Desc: Updates a specific hardware set
+
+    Returns:
+        200: updated hardware set object
+    """
+    req = request.get_json()
+    hardware_set = HardwareSet.objects(id=id).first()
+    hardware_set.update(**req)
+    hardware_set.reload()
+    return hardware_set.to_json(), 200
+
+@hardware.route('/<id>', methods=['DELETE'])
+@jwt_required()
+def hardware_delete(id):
+    """DELETE hardware/<id>
+
+    Desc: Deletes a specific hardware set from the database
+
+    Returns:
+        200: success message
+    """
+    HardwareSet.objects(id=id).delete()
+    return {'msg': 'Hardware set successfully deleted'}, 200


### PR DESCRIPTION
### Problem
Our API did not expose any endpoints to interact with the hardware sets in our database. This meant that our frontend could not access any of the hardware set data.

### Solution
Create CRUD (Create, Read, Update, Delete) operations for hardware sets. Now, an authorized user can create new hardware sets, get a list of all current hardware sets, update a specific hardware set, or delete a specific hardware set. All of these routes are protected with the JWT authentication, so only authorized users may use these endpoints.

### Testing
I tested all these endpoints in Postman. All of the requests are saved in a collection called Hardware Sets. I was able to create new hardware sets, read these sets, and modify/delete specific sets based on ID.

### Notes
This does not validate inputs in any way. That will be addressed in a future PR.

Closes #34 