### PR TITLE
Token Expiration Change

### DIFF
--- a/server/api/config.py
+++ b/server/api/config.py
@@ -1,5 +1,5 @@
 import os
-
+import datetime
 
 class Config:
     MONGODB_SETTINGS = {
@@ -10,3 +10,4 @@ class Config:
         'authentication_source': 'admin'
     }
     JWT_SECRET_KEY = os.environ['JWT_SECRET_KEY']
+    JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(days=14)


### PR DESCRIPTION
### Problem
The JWT authentication tokens were expiring after 15 minutes (the default for `flask_jwt_extended`. For most sites, you won't have to reauthenticate for somewhere around 2 weeks, which is quite a bit different.

### Solution
Change the expiration time for the authentication tokens to 14 days, or 2 weeks.

### Testing
I logged in and waited over 15 minutes and was still able to access a protected route. I didn't want to sit here for 2 weeks, but I'm fairly confident it's working properly.

Closes #48 