### PR TITLE
Backend CORS

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -2,8 +2,10 @@ from flask import Flask
 from database import db
 from api.config import Config
 from flask_jwt_extended import JWTManager
+from flask_cors import CORS
 
 jwt = JWTManager()
+cors = CORS()
 
 
 def create_app(config_class=Config):
@@ -12,6 +14,7 @@ def create_app(config_class=Config):
 
     db.init_app(app)
     jwt.init_app(app)
+    cors.init_app(app)
 
     from api.routes.main import main
     from api.routes.users import users

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,6 +2,7 @@ click==7.1.2
 dnspython==2.1.0
 email-validator==1.1.2
 Flask==1.1.2
+Flask-Cors==3.0.10
 Flask-JWT-Extended==4.1.0
 flask-mongoengine==1.0.0
 Flask-WTF==0.14.3
@@ -12,5 +13,6 @@ MarkupSafe==1.1.1
 mongoengine==0.23.0
 PyJWT==2.0.1
 pymongo==3.11.3
+six==1.15.0
 Werkzeug==1.0.1
 WTForms==2.3.3


### PR DESCRIPTION
### Problem
The server didn't enable Cross-Origin Resource Sharing, so requests coming from other domains were not allowed. This would have led to our client being unable to make requests to our server (quite a big issue).

### Solution
Using the `flask-cors` module, we can simply create a `CORS` object and initialize it with our flask app. This easily enables CORS on our API.

### Testing
Using the SwaggerUI web interface, there is an option to send a request in the format specified by our YAML files. Before adding CORS, this request was denied because the SwaggerUI server was hosted on a different domain (port 8080) than our API (port 5000). After adding CORS, I was able to successfully send a login request to the server.

### Notes
This does open our API up to _all_ domains, so we may want to look into how to restrict that when the time comes to deploy. I'm not entirely sure how the small details of CORS works, so that'll require some research. Also, it looks like we can now use SwaggerUI to test our routes (which will also force us to document along the way) instead of Postman. But we can use both also.

Closes #51 