### PR TITLE
Register API Token

### DIFF
--- a/server/api/routes/users.py
+++ b/server/api/routes/users.py
@@ -15,7 +15,7 @@ def login():
           Checks if an account exists and the password was incorrect
 
     Returns:
-        200: success - true
+        200: authentication token
         401: password was incorrect, unauthorized access
         404: no account was found or field was empty
     """
@@ -50,7 +50,7 @@ def register():
           Ensures new accounts are not duplicates
 
     Returns:
-        201: new user object
+        201: authentication token
         401: validation error, unauthorized access
         409: duplicate account, conflict with database
     """
@@ -67,4 +67,8 @@ def register():
         }, 409
 
     new_user = User(**req).save()
-    return new_user.to_json(), 201
+
+    access_token = create_access_token(identity=new_user)
+    return {
+        'token': access_token
+    }, 201

--- a/swagger/EndpointDocumentation/Users/register.yml
+++ b/swagger/EndpointDocumentation/Users/register.yml
@@ -11,13 +11,17 @@ post:
         schema:
           type: object
           properties:
+            first_name:
+              type: string
+            last_name:
+              type: string
             email:
               type: string
             password:
               type: string
   responses:
     401:
-      description: Invalid information
+      description: Invalid information. Each field in the response corresponds to the error for that input.
       content:
         application/json:
           schema:
@@ -28,7 +32,7 @@ post:
               password:
                 type: string
     409:
-      description: Duplicate account
+      description: Duplicate account. Each field in the response corresponds to the error for that input.
       content:
         application/json:
           schema:
@@ -38,14 +42,12 @@ post:
                 type: string
               password:
                 type: string
-    200:
+    201:
       description: Registration successful
       content:
         application/json:
           schema:
             type: object
             properties:
-              email:
-                type: string
-              password:
+              token:
                 type: string


### PR DESCRIPTION
### Problem
The register route only returned the newly created user object, so if the client wanted to authenticate a new user, they would have to create the user with this route and then send another request to the login route to get the JWT.

### Solution
Modify the Register route so it generates a new JWT upon successful registration and returns that token in the JSON body.

### Testing
I used the modified Swagger interface to send a request to the register route. If I didn't meet all the validation requirements, I was still not given a token, but if I gave a proper set of credentials, a token was returned to me in the same format as the login route.

Closes #56 