### PR TITLE
Basic CRUD for projects

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -16,8 +16,10 @@ def create_app(config_class=Config):
     from api.routes.main import main
     from api.routes.users import users
     from api.routes.hardware import hardware
+    from api.routes.projects import projects
     app.register_blueprint(main)
     app.register_blueprint(users, url_prefix='/users')
     app.register_blueprint(hardware, url_prefix='/hardware')
+    app.register_blueprint(projects, url_prefix='/projects')
 
     return app

--- a/server/api/routes/projects.py
+++ b/server/api/routes/projects.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request
 from database import Projects
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import get_jwt_identity, jwt_required
 # from database import User
 import json
 
@@ -15,6 +15,7 @@ def projects_create():
         201: newly created project
     """
     req = request.get_json()
+    req["creator_id"] = get_jwt_identity()["_id"]["$oid"]
     new_project = Projects(**req).save()
     return new_project.to_json(), 201
 

--- a/server/api/routes/projects.py
+++ b/server/api/routes/projects.py
@@ -6,3 +6,51 @@ import json
 
 projects = Blueprint('projects', __name__)
 
+@projects.route('/', methods=['POST'])
+@jwt_required()
+def projects_create():
+    """POST projects/
+    Desc: Creates a new project
+    Returns:
+        201: newly created project
+    """
+    req = request.get_json()
+    new_project = Projects(**req).save()
+    return new_project.to_json(), 201
+
+
+@projects.route('/', methods=['GET'])
+@jwt_required()
+def projects_read():
+    """GET projects/
+    Desc: Gets all available projects
+    Returns:
+        200: all projects in the database
+    """
+    return Projects.objects.to_json(), 200
+
+
+@projects.route('/<id>', methods=['PUT'])
+@jwt_required()
+def projects_update(id):
+    """PUT projects/<id>
+    Desc: Updates a specific projects
+    Returns:
+        200: updated projects object
+    """
+    req = request.get_json()
+    curr_project = Projects.objects(id=id).first()
+    curr_project.update(**req)
+    curr_project.reload()
+    return curr_project.to_json(), 200
+
+@projects.route('/<id>', methods=['DELETE'])
+@jwt_required()
+def projects_delete(id):
+    """DELETE projects/<id>
+    Desc: Deletes a specific project from the database
+    Returns:
+        200: success message
+    """
+    Projects.objects(id=id).delete()
+    return {'msg': 'Projects set successfully deleted'}, 200

--- a/server/api/routes/projects.py
+++ b/server/api/routes/projects.py
@@ -24,11 +24,12 @@ def projects_create():
 @jwt_required()
 def projects_read():
     """GET projects/
-    Desc: Gets all available projects
+    Desc: Gets all available projects associated with the current user
     Returns:
         200: all projects in the database
     """
-    return Projects.objects.to_json(), 200
+    return Projects.objects(creator_id=get_jwt_identity()["_id"]["$oid"]).to_json(), 200
+
 
 
 @projects.route('/<id>', methods=['PUT'])

--- a/swagger/EndpointDocumentation/Projects/project_w_id.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_id.yml
@@ -1,0 +1,76 @@
+put:
+  tags:
+    - projects
+  summary: Attempt to update existing project
+  operationId: updateProject
+  parameters:
+    - in: path
+      name: projectID
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the project to be updated
+  requestBody:
+    required: true
+    description: Project Info
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+  responses:
+    200:
+      description: Project Successfully Updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              _id:
+                type: object
+                properties:
+                  $oid: 
+                    type: string
+                    example: '605e4e9c2226f89fb151d0a1'
+              name:
+                type: string
+                example: 'Updated Name'
+              description:
+                type: string
+                example: 'Updated Description'
+              creator_id:
+                type: object
+                properties:
+                  $oid: 
+                    type: string
+                    example: '6059234f9885cb36c1964f52'
+
+delete:
+  tags:
+    - projects
+  summary: Attempt to delete existing project
+  operationId: updateProject
+  parameters:
+    - in: path
+      name: projectID
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the project to be deleted
+  requestBody:
+    required: false
+  responses:
+    200:
+      description: Project Successfully Updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string 
+                example: 'Projects set successfully deleted'

--- a/swagger/EndpointDocumentation/Projects/projects.yml
+++ b/swagger/EndpointDocumentation/Projects/projects.yml
@@ -1,0 +1,90 @@
+post:
+  tags:
+    - projects
+  summary: Attempt to create new project
+  operationId: createProject
+  requestBody:
+    required: true
+    description: Project Info
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+  responses:
+    201:
+      description: Project Successfully Created
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              _id:
+                type: object
+                properties:
+                  $oid: 
+                    type: string
+                    example: '605e4e9c2226f89fb151d0a1'
+              name:
+                type: string
+                example: 'Newly Created Name'
+              description:
+                type: string
+                example: 'Newly Created Description'
+              creator_id:
+                type: object
+                properties:
+                  $oid: 
+                    type: string
+                    example: '6059234f9885cb36c1964f52'
+
+get:
+  tags:
+    - projects
+  summary: Attempt to read all projects
+  operationId: readProject
+  requestBody:
+    required: false
+  responses:
+    200:
+      description: Projects Successfully Read
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                _id:
+                  type: object
+                  properties:
+                    $oid: 
+                      type: string
+                name:
+                  type: string
+                description:
+                  type: string
+                creator_id:
+                  type: object
+                  properties:
+                    $oid: 
+                      type: string
+            example: 
+            - _id: 
+                $oid: '605e4e9c2226f89fb151d0a1'
+              name: 'Project 1 Name'
+              description: 'Project 1 Description'
+              creator_id:
+                $oid: '6059234f9885cb36c1964f52'
+
+            - _id: 
+                $oid: '605926640605c11c5b48bcdd'
+              name: 'Project 2 Name'
+              description: 'Project 2 Description'
+              creator_id:
+                $oid: '605914c9d4128bb131f7829e'
+

--- a/swagger/EndpointDocumentation/Projects/projects.yml
+++ b/swagger/EndpointDocumentation/Projects/projects.yml
@@ -45,7 +45,7 @@ post:
 get:
   tags:
     - projects
-  summary: Attempt to read all projects
+  summary: Attempt to read all projects associated with the current user
   operationId: readProject
   requestBody:
     required: false
@@ -86,5 +86,5 @@ get:
               name: 'Project 2 Name'
               description: 'Project 2 Description'
               creator_id:
-                $oid: '605914c9d4128bb131f7829e'
+                $oid: '6059234f9885cb36c1964f52'
 

--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -10,12 +10,18 @@ servers:
 tags:
   - name: users
     description: Endpoints regarding user management
+  - name: projects
+    description: Endpoints regarding projects
 
 paths:
   /users/login:
     $ref: ./EndpointDocumentation/Users/login.yml
   /users/register:
     $ref: ./EndpointDocumentation/Users/register.yml
+  /projects/:
+    $ref: ./EndpointDocumentation/Projects/projects.yml
+  /projects/{projectID}:
+    $ref: ./EndpointDocumentation/Projects/project_w_id.yml
 
 
 


### PR DESCRIPTION
Problem
Our API did not expose any endpoints to interact with the projects in our database. The frontend did not have access to project information

Solution
Create CRUD (Create, Read, Update, Delete) operations for projects. Projects have 3 fields: name, description, and creator id. All of these routes are protected with the JWT authentication, so only authorized users may use these endpoints.

Testing
I tested all these endpoints in Postman. I was able to Create, Read, Update, Delete projects in the project's collection in MongoDB.

Notes
We have not decided if some of the fields should stay immutable such as creator id. This does not validate inputs in any way. That will be addressed in a future PR.

Closes #27