### PR TITLE
Backend/project-by-ID

### DIFF
--- a/server/api/routes/projects.py
+++ b/server/api/routes/projects.py
@@ -36,6 +36,26 @@ def projects_read():
     """
     return Projects.objects(creator_id=get_jwt_identity()["_id"]["$oid"]).to_json(), 200
 
+@projects.route('/<id>', methods=['GET'])
+@jwt_required()
+def projects_read_id(id):
+    """GET projects/<id>
+    Desc: Gets a project by project id
+    Returns:
+        200: project found in the database and returned
+        404: project not found
+        422: validation errors
+    """
+    try:
+        curr_project = Projects.objects(id=id).first()
+        if curr_project:
+            return curr_project.to_json(), 200
+        else:
+            return {'msg': 'Project not found'}, 404
+    except ValidationError as e:
+        return parse_error(e), 422
+
+
 
 @projects.route('/<id>', methods=['PUT'])
 @jwt_required()

--- a/swagger/EndpointDocumentation/Projects/project_w_id.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_id.yml
@@ -61,12 +61,9 @@ get:
           schema:
             type: object
             properties:
-              name:
+              msg:
                 type: string
-                example: "String field too short"
-              description:
-                type: string
-                example: "String field too long"
+                example: "<projectID> is not a valid ObjectId"
 put:
   tags:
     - projects

--- a/swagger/EndpointDocumentation/Projects/project_w_id.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_id.yml
@@ -1,3 +1,72 @@
+
+get:
+  tags:
+    - projects
+  summary: Attempt to read a project associated with an project ID
+  operationId: readProject
+  parameters:
+    - in: path
+      name: projectID
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the project to be updated
+  requestBody:
+    required: true
+  responses:
+    200:
+      description: Projects based on ID read successfully
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                _id:
+                  type: object
+                  properties:
+                    $oid:
+                      type: string
+                name:
+                  type: string
+                description:
+                  type: string
+                creator_id:
+                  type: object
+                  properties:
+                    $oid:
+                      type: string
+            example:
+              - _id:
+                  $oid: "605e4e9c2226f89fb151d0a1"
+                name: "Project 1 Name"
+                description: "Project 1 Description"
+                creator_id:
+                  $oid: "6059234f9885cb36c1964f52"
+    404:
+      description: Project Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Project not found"
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                example: "String field too short"
+              description:
+                type: string
+                example: "String field too long"
 put:
   tags:
     - projects


### PR DESCRIPTION
### Problem
The GET request only returned projects associated with the currently logged-in user. Other users are unable to see projects that are not theirs

### Solution
Add a new GET route in projects with `/<id>`, a project object ID, that returns the project object as a json if found.  Validation errors and project no found are handled.

### Testing
Added a new request to Postman that sends a GET request with a project ID. The project can be associated with the user or created by different users.

Closes #63