### PR TITLE
Associates Hardware Sets with Projects

### DIFF
--- a/server/api/routes/projects.py
+++ b/server/api/routes/projects.py
@@ -36,6 +36,7 @@ def projects_read():
     """
     return Projects.objects(creator_id=get_jwt_identity()["_id"]["$oid"]).to_json(), 200
 
+
 @projects.route('/<id>', methods=['GET'])
 @jwt_required()
 def projects_read_id(id):
@@ -54,7 +55,6 @@ def projects_read_id(id):
             return {'msg': 'Project not found'}, 404
     except ValidationError as e:
         return parse_error(e), 422
-
 
 
 @projects.route('/<id>', methods=['PUT'])

--- a/server/database/models.py
+++ b/server/database/models.py
@@ -25,10 +25,12 @@ class Projects(db.Document):
 
     Field:
         name: the name of the project
+        hardware: list of hardware sets associated with this project
         description: description of the project
     """
     name = db.StringField(required=True, min_length=1, max_length=20)
     description = db.StringField(required=True, min_length=5)
+    hardware = db.ListField(db.DictField())
     creator_id = db.ObjectIdField(required=True)
 
 

--- a/swagger/EndpointDocumentation/Projects/project_w_id.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_id.yml
@@ -1,4 +1,3 @@
-
 get:
   tags:
     - projects
@@ -88,6 +87,16 @@ put:
               type: string
             description:
               type: string
+            hardware:
+              type: array
+              items:
+                type: object
+                properties:
+                  _id:
+                    type: string
+                    example: "605e4e9c2226f89fb151d0a1"
+                  amount:
+                    type: integer
   responses:
     200:
       description: Project Successfully Updated
@@ -108,6 +117,16 @@ put:
               description:
                 type: string
                 example: "Updated Description"
+              hardware:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    _id:
+                      type: string
+                      example: "605e4e9c2226f89fb151d0a1"
+                    amount:
+                      type: integer
               creator_id:
                 type: object
                 properties:

--- a/swagger/EndpointDocumentation/Projects/projects.yml
+++ b/swagger/EndpointDocumentation/Projects/projects.yml
@@ -15,6 +15,16 @@ post:
               type: string
             description:
               type: string
+            hardware:
+              type: array
+              items:
+                type: object
+                properties:
+                  _id:
+                    type: string
+                    example: "605e4e9c2226f89fb151d0a1"
+                  amount:
+                    type: integer
   responses:
     201:
       description: Project Successfully Created
@@ -35,6 +45,16 @@ post:
               description:
                 type: string
                 example: "Newly Created Description"
+              hardware:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    _id:
+                      type: string
+                      example: "605e4e9c2226f89fb151d0a1"
+                    amount:
+                      type: integer
               creator_id:
                 type: object
                 properties:
@@ -81,6 +101,15 @@ get:
                   type: string
                 description:
                   type: string
+                hardware:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                      amount:
+                        type: integer
                 creator_id:
                   type: object
                   properties:
@@ -91,6 +120,9 @@ get:
                   $oid: "605e4e9c2226f89fb151d0a1"
                 name: "Project 1 Name"
                 description: "Project 1 Description"
+                hardware:
+                  - _id: "605e4e9c2226f89fb151d0a1"
+                    amount: 200
                 creator_id:
                   $oid: "6059234f9885cb36c1964f52"
 
@@ -98,5 +130,10 @@ get:
                   $oid: "605926640605c11c5b48bcdd"
                 name: "Project 2 Name"
                 description: "Project 2 Description"
+                hardware:
+                  - _id: "605e4e9c2226f89fb151d0a1"
+                    amount: 200
+                  - _id: "605e4e9c2226f89fb151d0a2"
+                    amount: 100
                 creator_id:
                   $oid: "6059234f9885cb36c1964f52"


### PR DESCRIPTION
### Problem
Hardware sets and projects were completely disassociated from one another. This would cause problems if we want to let a user check out some of a hardware set for a particular project. We would only have been able to decrease the availability of the hardware set without updating anything regarding the project.

### Solution
Add a list field in the Projects model to store objects describing which hardware sets and how much of each have been reserved for a particular project. This may not be the best database model if a single project checks out lots of hardware sets, but it works for now. In the future, we may want to update this for more scalability. From the client-side now, they need to include a list of hardware set description objects (format specified by Swagger) if a hardware set is being checked out for a particular project.

### Testing
I tested this using Postman routes. The routes that previously worked still do. The tests for projects have not yet been completed so that PR will need to include testing for this as well. But for now, it seems to be working. 

Closes #88 