### PR TITLE
Backend/hardware validation

### DIFF
--- a/server/database/models.py
+++ b/server/database/models.py
@@ -41,5 +41,5 @@ class HardwareSet(db.Document):
         capacity: hardware set capacity (how many we own)
         available: hardware set availability (how many are not currently checked out)
     """
-    capacity = db.IntField(required=True)
-    available = db.IntField(required=True)
+    capacity = db.IntField(required=True, min_value=0)
+    available = db.IntField(required=True, min_value=0)


### PR DESCRIPTION
### Problem
When working with hardware set, the inputs weren't being validated. With that setup, if an input was not accepted by the database, the server wouldn't respond smoothly. This would cause the client to not be aware of what specific errors are being thrown.

### Solution
Validate the input using the mongoengine validators and handle the errors thrown by that engine. I created a method to parse a ValidationError object and generate a dictionary of its fields to then return to the client. This way, the client can see what's wrong with each field.

### Testing
I tested this with Postman by sending correct and incorrect data as part of the JSON body. All the known errors were caught and handled gracefully.

Notes
I used error code 422 to represent incorrect information. It's what I saw online as the best one to use for this case.

Closes #49 #97 #98