### PR TITLE
User Provided Project IDs

### DIFF
--- a/server/api/routes/projects.py
+++ b/server/api/routes/projects.py
@@ -48,7 +48,7 @@ def projects_read_id(id):
         422: validation errors
     """
     try:
-        curr_project = Projects.objects(id=id).first()
+        curr_project = Projects.objects(project_id=id).first()
         if curr_project:
             return curr_project.to_json(), 200
         else:

--- a/server/database/models.py
+++ b/server/database/models.py
@@ -32,6 +32,7 @@ class Projects(db.Document):
     description = db.StringField(required=True, min_length=5)
     hardware = db.ListField(db.DictField())
     creator_id = db.ObjectIdField(required=True)
+    project_id = db.StringField(required=True, unique=True)
 
 
 class HardwareSet(db.Document):

--- a/swagger/EndpointDocumentation/Projects/project_w_id.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_id.yml
@@ -5,11 +5,11 @@ get:
   operationId: readProject
   parameters:
     - in: path
-      name: projectID
+      name: project_id
       schema:
         type: string
       required: true
-      description: The Object ID of the project to be updated
+      description: The user inputted project ID of the project to be updated
   requestBody:
     required: true
   responses:
@@ -62,7 +62,7 @@ get:
             properties:
               msg:
                 type: string
-                example: "<projectID> is not a valid ObjectId"
+                example: "<projectID> is not a valid String"
 put:
   tags:
     - projects

--- a/swagger/EndpointDocumentation/Projects/projects.yml
+++ b/swagger/EndpointDocumentation/Projects/projects.yml
@@ -25,6 +25,8 @@ post:
                     example: "605e4e9c2226f89fb151d0a1"
                   amount:
                     type: integer
+            project_id:
+              type: string
   responses:
     201:
       description: Project Successfully Created


### PR DESCRIPTION
### Problem
Users were not able to create projects with custom ID strings and had to rely on the automatically generated one.

### Solution
Add another `String` field when users create projects called `project_id`. This ID is a `String` rather than an `ObjectField` because it makes more sense for an end user to give a project a custom string similar to how you can give GitHub repositories custom IDs. This also allows the user to look up their projects with the same ID, making it easier to share links within a team.

### Testing
I tested this using Postman to make sure creating a new project would allow the user to input a project ID string of their choice.

Closes #94 