### PR TITLE
Backend/hardware by ID

### DIFF
--- a/server/api/routes/hardware.py
+++ b/server/api/routes/hardware.py
@@ -38,6 +38,18 @@ def hardware_read():
     """
     return HardwareSet.objects.to_json(), 200
 
+@hardware.route('/<id>', methods=['GET'])
+@jwt_required()
+def hardware_read():
+    """GET hardware/<id>
+
+    Desc: Gets hardware set associated with a project ID
+
+    Returns:
+        200: all hardware sets in the database
+    """
+    return HardwareSet.objects.to_json(), 200
+
 
 @hardware.route('/<id>', methods=['PUT'])
 @jwt_required()


### PR DESCRIPTION
### Problem
The frontend was not able to see the hardware sets that are associated with a project

### Solution
Create another GET this time with <id> as the project object id. This will return the list of Hardware Objects that are associated with the project. If the project does not have any hardware sets, it will return an empty list


### Testing
I tested this using Postman to make sure a list was returned or a msg saying the project does not exist. Validation errors are also caught and returned accordingly

Closes #96