### PR TITLE
Check-out & Check-in Routes

### DIFF
--- a/server/api/routes/hardware.py
+++ b/server/api/routes/hardware.py
@@ -76,6 +76,19 @@ def hardware_checkout(id):
             hardware_set = HardwareSet.objects(id=id).first()
             hardware_set.update(dec__available=req["amount"])
             hardware_set.reload()
+            project_hardware = project.hardware
+            found = False
+            for hardware in project_hardware:
+                if hardware["_id"] == id:
+                    found = True
+                    hardware["amount"] += req["amount"]
+            if not found:
+                project_hardware.append({
+                    "_id": id,
+                    "amount": req["amount"]
+                })
+            project.update(hardware=project_hardware)
+            project.reload()
             return hardware_set.to_json(), 200
         else:
             return {'msg': 'Project not found'}, 404


### PR DESCRIPTION
### Problem
In order to check out or check in a hardware set, our client needed to be aware of how the API operated internally. This left lots of room for error and made the lives of the frontend team more difficult than needed.

### Solution
Create routes for checking in and checking out the routes on the API that handles all the database updates internally with one API call. Both checking in and out only requires one route each.

### Testing
I tested this by creating a project and hardware set and checking in/out a portion of the hardware set for that particular project.

### Notes
This does not add Swagger docs as there are currently none for the Hardware Sets API, so I'll just add those later all at once. 

Closes #93 