### PR TITLE
Add name field to hardware model

### DIFF
--- a/server/api/routes/hardware.py
+++ b/server/api/routes/hardware.py
@@ -62,7 +62,6 @@ def hardware_read_id(id):
         return parse_error(e), 422
 
 
-
 @hardware.route('/<id>', methods=['PUT'])
 @jwt_required()
 def hardware_update(id):

--- a/server/database/models.py
+++ b/server/database/models.py
@@ -43,6 +43,6 @@ class HardwareSet(db.Document):
         capacity: hardware set capacity (how many we own)
         available: hardware set availability (how many are not currently checked out)
     """
-    name = db.StringField(required=True, min_length=1, max_length=20)
+    name = db.StringField(required=True, unique=True, min_length=1, max_length=20)
     capacity = db.IntField(required=True, min_value=0)
     available = db.IntField(required=True, min_value=0)

--- a/server/database/models.py
+++ b/server/database/models.py
@@ -39,8 +39,10 @@ class HardwareSet(db.Document):
     """Hardware Set for checkout
 
     Fields:
+        name: the name of the project
         capacity: hardware set capacity (how many we own)
         available: hardware set availability (how many are not currently checked out)
     """
+    name = db.StringField(required=True, min_length=1, max_length=20)
     capacity = db.IntField(required=True, min_value=0)
     available = db.IntField(required=True, min_value=0)

--- a/server/database/models.py
+++ b/server/database/models.py
@@ -43,6 +43,6 @@ class HardwareSet(db.Document):
         capacity: hardware set capacity (how many we own)
         available: hardware set availability (how many are not currently checked out)
     """
-    name = db.StringField(required=True, unique=True, min_length=1, max_length=20)
+    name = db.StringField(required=True, unique=True, min_length=1)
     capacity = db.IntField(required=True, min_value=0)
     available = db.IntField(required=True, min_value=0)

--- a/server/database/models.py
+++ b/server/database/models.py
@@ -39,7 +39,7 @@ class HardwareSet(db.Document):
     """Hardware Set for checkout
 
     Fields:
-        name: the name of the project
+        name: the name of the Hardware Set
         capacity: hardware set capacity (how many we own)
         available: hardware set availability (how many are not currently checked out)
     """

--- a/swagger/EndpointDocumentation/Hardware/hardware.yml
+++ b/swagger/EndpointDocumentation/Hardware/hardware.yml
@@ -11,6 +11,9 @@ post:
         schema:
           type: object
           properties:
+            name:
+              type: string
+              example: "Hardware Set 1"
             capacity:
               type: integer
               example: 400
@@ -33,9 +36,12 @@ post:
                     type: string
                     example: "606f5bc7830ea5bf5e4187c9"
               name:
+                type: string
+                example: "Hardware Set 1"
+              capacity:
                 type: integer
                 example: 400
-              description:
+              available:
                 type: integer
                 example: 50
     422:
@@ -45,12 +51,9 @@ post:
           schema:
             type: object
             properties:
-              name:
+              msg:
                 type: string
-                example: "String field too short"
-              description:
-                type: string
-                example: "String field too long"
+                example: "'606e2b692a216b8f986af36' is not a valid ObjectId, it must be a 12-byte input or a 24-character hex string"
 
 get:
   tags:
@@ -74,16 +77,20 @@ get:
                   properties:
                     $oid:
                       type: string
+                name:
+                  type: string
                 capacity:
-                  type: string
+                  type: integer
                 available:
-                  type: string
+                  type: integer
             example:
               - _id:
                   $oid: "606e2b692a216b8f986af361"
+                name: "Hardware Set 1"
                 capacity: 400
                 available: 50
               - _id:
                   $oid: "606e2b782a216b8f986af364"
+                name: "Hardware Set 2"
                 capacity: 600
                 available: 100

--- a/swagger/EndpointDocumentation/Hardware/hardware.yml
+++ b/swagger/EndpointDocumentation/Hardware/hardware.yml
@@ -1,0 +1,89 @@
+post:
+  tags:
+    - hardware
+  summary: Attempt to Add new Hardware Set
+  operationId: createHardwareSet
+  requestBody:
+    required: true
+    description: Hardware Set Info. `capacity` and `available` must both be postive values.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            capacity:
+              type: integer
+              example: 400
+            available:
+              type: integer
+              example: 50
+          
+  responses:
+    201:
+      description: Hardware Set Successfully Created
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              _id:
+                type: object
+                properties:
+                  $oid:
+                    type: string
+                    example: "606f5bc7830ea5bf5e4187c9"
+              name:
+                type: integer
+                example: 400
+              description:
+                type: integer
+                example: 50
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                example: "String field too short"
+              description:
+                type: string
+                example: "String field too long"
+
+get:
+  tags:
+    - hardware
+  summary: Attempt to read all Hardware Sets
+  operationId: readHardwareSet
+  requestBody:
+    required: false
+  responses:
+    200:
+      description: Hardware Sets Successfully Read
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                _id:
+                  type: object
+                  properties:
+                    $oid:
+                      type: string
+                capacity:
+                  type: string
+                available:
+                  type: string
+            example:
+              - _id:
+                  $oid: "606e2b692a216b8f986af361"
+                capacity: 400
+                available: 50
+              - _id:
+                  $oid: "606e2b782a216b8f986af364"
+                capacity: 600
+                available: 100

--- a/swagger/EndpointDocumentation/Hardware/hardware_hw_id.yml
+++ b/swagger/EndpointDocumentation/Hardware/hardware_hw_id.yml
@@ -18,6 +18,8 @@ put:
         schema:
           type: object
           properties:
+            name:
+              type: string
             capacity:
               type: integer
             available:
@@ -36,6 +38,9 @@ put:
                   $oid:
                     type: string
                     example: "606e2b692a216b8f986af361"
+              name:
+                type: string
+                example: "Hardware Set 1"
               capacity:
                 type: integer
                 example: 500

--- a/swagger/EndpointDocumentation/Hardware/hardware_hw_id.yml
+++ b/swagger/EndpointDocumentation/Hardware/hardware_hw_id.yml
@@ -1,0 +1,110 @@
+put:
+  tags:
+    - hardware
+  summary: Attempt to update existing Hardware Set
+  operationId: updateHardwareSet
+  parameters:
+    - in: path
+      name: hardwareID
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the hardware set to be updated
+  requestBody:
+    required: true
+    description: Hardware set Info
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            capacity:
+              type: integer
+            available:
+              type: integer
+  responses:
+    200:
+      description: Hardware Set Successfully Updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              _id:
+                type: object
+                properties:
+                  $oid:
+                    type: string
+                    example: "606e2b692a216b8f986af361"
+              capacity:
+                type: integer
+                example: 500
+              available:
+                type: integer
+                example: 50
+    404:
+      description: Hardware Set Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Hardware Set not found"
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Integer value is too small"
+
+delete:
+  tags:
+    - hardware
+  summary: Attempt to delete existing hardware set
+  operationId: deleteHardwareSet
+  parameters:
+    - in: path
+      name: hardwareID
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the hardware set to be deleted
+  requestBody:
+    required: false
+  responses:
+    200:
+      description: Hardware set Successfully deleted
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Hardware set successfully deleted"
+    404:
+      description: Hardware set Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Hardware set not found"
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "'606e2b692a216b8f986af36' is not a valid ObjectId, it must be a 12-byte input or a 24-character hex string"

--- a/swagger/EndpointDocumentation/Hardware/hardware_p_id.yml
+++ b/swagger/EndpointDocumentation/Hardware/hardware_p_id.yml
@@ -27,6 +27,8 @@ get:
                   properties:
                     $oid:
                       type: string
+                name:
+                  type: string
                 capacity:
                   type: integer
                 available:
@@ -34,6 +36,7 @@ get:
             example:
               - _id:
                   $oid: "606e2b692a216b8f986af361"
+                name: "Hardware Set 1"
                 capacity: 400
                 available: 50
     404:

--- a/swagger/EndpointDocumentation/Hardware/hardware_p_id.yml
+++ b/swagger/EndpointDocumentation/Hardware/hardware_p_id.yml
@@ -1,0 +1,58 @@
+get:
+  tags:
+    - hardware
+  summary: Attempt to read all hardware sets associated with an project ID
+  operationId: readHardwareSet
+  parameters:
+    - in: path
+      name: project_id
+      schema:
+        type: string
+      required: true
+      description: The user inputted project object ID to return all the hardware sets associated with that project.
+  requestBody:
+    required: true
+  responses:
+    200:
+      description: Hardware Set based on porject ID read successfully. If no hardware set are associated, then an empty list is returned.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                _id:
+                  type: object
+                  properties:
+                    $oid:
+                      type: string
+                capacity:
+                  type: integer
+                available:
+                  type: integer
+            example:
+              - _id:
+                  $oid: "606e2b692a216b8f986af361"
+                capacity: 400
+                available: 50
+    404:
+      description: Project Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Project not found"
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "<projectID> is not a valid String"

--- a/swagger/EndpointDocumentation/Projects/project_w_id.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_id.yml
@@ -66,3 +66,146 @@ get:
               msg:
                 type: string
                 example: "<projectID> is not a valid String"
+
+put:
+  tags:
+    - projects
+  summary: Attempt to update existing project
+  operationId: updateProject
+  parameters:
+    - in: path
+      name: projectID
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the project to be updated
+  requestBody:
+    required: true
+    description: Project Info
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+            hardware:
+              type: array
+              items:
+                type: object
+                properties:
+                  _id:
+                    type: string
+                    example: "605e4e9c2226f89fb151d0a1"
+                  amount:
+                    type: integer
+  responses:
+    200:
+      description: Project Successfully Updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              _id:
+                type: object
+                properties:
+                  $oid:
+                    type: string
+                    example: "605e4e9c2226f89fb151d0a1"
+              name:
+                type: string
+                example: "Updated Name"
+              description:
+                type: string
+                example: "Updated Description"
+              hardware:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    _id:
+                      type: string
+                      example: "605e4e9c2226f89fb151d0a1"
+                    amount:
+                      type: integer
+              creator_id:
+                type: object
+                properties:
+                  $oid:
+                    type: string
+                    example: "6059234f9885cb36c1964f52"
+    404:
+      description: Project Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Project not found"
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                example: "String field too short"
+              description:
+                type: string
+                example: "String field too long"
+
+delete:
+  tags:
+    - projects
+  summary: Attempt to delete existing project
+  operationId: deleteProject
+  parameters:
+    - in: path
+      name: projectID
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the project to be deleted
+  requestBody:
+    required: false
+  responses:
+    200:
+      description: Project Successfully Updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Projects set successfully deleted"
+    404:
+      description: Project Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Project not found"
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                example: "String field too short"
+              description:
+                type: string
+                example: "String field too long"

--- a/swagger/EndpointDocumentation/Projects/project_w_id.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_id.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - projects
-  summary: Attempt to read a project associated with an project ID
+  summary: Attempt to read a project associated with a project ID
   operationId: readProject
   parameters:
     - in: path
@@ -9,7 +9,7 @@ get:
       schema:
         type: string
       required: true
-      description: The user inputted project ID of the project to be updated
+      description: The user inputted project ID of the project to be read
   requestBody:
     required: true
   responses:
@@ -36,6 +36,8 @@ get:
                   properties:
                     $oid:
                       type: string
+                project_id:
+                  type: string
             example:
               - _id:
                   $oid: "605e4e9c2226f89fb151d0a1"
@@ -43,6 +45,7 @@ get:
                 description: "Project 1 Description"
                 creator_id:
                   $oid: "6059234f9885cb36c1964f52"
+                project_id: "project-id-123"
     404:
       description: Project Not Found
       content:
@@ -63,145 +66,3 @@ get:
               msg:
                 type: string
                 example: "<projectID> is not a valid String"
-put:
-  tags:
-    - projects
-  summary: Attempt to update existing project
-  operationId: updateProject
-  parameters:
-    - in: path
-      name: projectID
-      schema:
-        type: string
-      required: true
-      description: The Object ID of the project to be updated
-  requestBody:
-    required: true
-    description: Project Info
-    content:
-      application/json:
-        schema:
-          type: object
-          properties:
-            name:
-              type: string
-            description:
-              type: string
-            hardware:
-              type: array
-              items:
-                type: object
-                properties:
-                  _id:
-                    type: string
-                    example: "605e4e9c2226f89fb151d0a1"
-                  amount:
-                    type: integer
-  responses:
-    200:
-      description: Project Successfully Updated
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              _id:
-                type: object
-                properties:
-                  $oid:
-                    type: string
-                    example: "605e4e9c2226f89fb151d0a1"
-              name:
-                type: string
-                example: "Updated Name"
-              description:
-                type: string
-                example: "Updated Description"
-              hardware:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    _id:
-                      type: string
-                      example: "605e4e9c2226f89fb151d0a1"
-                    amount:
-                      type: integer
-              creator_id:
-                type: object
-                properties:
-                  $oid:
-                    type: string
-                    example: "6059234f9885cb36c1964f52"
-    404:
-      description: Project Not Found
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              msg:
-                type: string
-                example: "Project not found"
-    422:
-      description: Validation Errors
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              name:
-                type: string
-                example: "String field too short"
-              description:
-                type: string
-                example: "String field too long"
-
-delete:
-  tags:
-    - projects
-  summary: Attempt to delete existing project
-  operationId: updateProject
-  parameters:
-    - in: path
-      name: projectID
-      schema:
-        type: string
-      required: true
-      description: The Object ID of the project to be deleted
-  requestBody:
-    required: false
-  responses:
-    200:
-      description: Project Successfully Updated
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              msg:
-                type: string
-                example: "Projects set successfully deleted"
-    404:
-      description: Project Not Found
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              msg:
-                type: string
-                example: "Project not found"
-    422:
-      description: Validation Errors
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              name:
-                type: string
-                example: "String field too short"
-              description:
-                type: string
-                example: "String field too long"

--- a/swagger/EndpointDocumentation/Projects/project_w_oid.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_oid.yml
@@ -1,0 +1,137 @@
+put:
+  tags:
+    - projects
+  summary: Attempt to update existing project by object ID
+  operationId: updateProject
+  parameters:
+    - in: path
+      name: project_oid
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the project to be updated
+  requestBody:
+    required: true
+    description: Project Info
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+            project_id:
+              type: string
+  responses:
+    200:
+      description: Project Successfully Updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              _id:
+                type: object
+                properties:
+                  $oid:
+                    type: string
+                    example: "605e4e9c2226f89fb151d0a1"
+              name:
+                type: string
+                example: "Updated Name"
+              description:
+                type: string
+                example: "Updated Description"
+              hardware:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    _id:
+                      type: string
+                      example: "605e4e9c2226f89fb151d0a1"
+                    amount:
+                      type: integer
+              creator_id:
+                type: object
+                properties:
+                  $oid:
+                    type: string
+                    example: "6059234f9885cb36c1964f52"
+              project_id:
+                type: string
+                example: "project-id-123"
+    404:
+      description: Project Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Project not found"
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                example: "String field too short"
+              description:
+                type: string
+                example: "String field too long"
+
+delete:
+  tags:
+    - projects
+  summary: Attempt to delete existing project by object ID
+  operationId: deleteProject
+  parameters:
+    - in: path
+      name: project_oid
+      schema:
+        type: string
+      required: true
+      description: The Object ID of the project to be deleted
+  requestBody:
+    required: false
+  responses:
+    200:
+      description: Project Successfully Updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Projects set successfully deleted"
+    404:
+      description: Project Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              msg:
+                type: string
+                example: "Project not found"
+    422:
+      description: Validation Errors
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                example: "String field too short"
+              description:
+                type: string
+                example: "String field too long"

--- a/swagger/EndpointDocumentation/Projects/projects.yml
+++ b/swagger/EndpointDocumentation/Projects/projects.yml
@@ -15,16 +15,6 @@ post:
               type: string
             description:
               type: string
-            hardware:
-              type: array
-              items:
-                type: object
-                properties:
-                  _id:
-                    type: string
-                    example: "605e4e9c2226f89fb151d0a1"
-                  amount:
-                    type: integer
             project_id:
               type: string
   responses:
@@ -63,6 +53,9 @@ post:
                   $oid:
                     type: string
                     example: "6059234f9885cb36c1964f52"
+              project_id:
+                type: string
+                example: "project-id-123"
     422:
       description: Validation Errors
       content:
@@ -76,6 +69,9 @@ post:
               description:
                 type: string
                 example: "String field too long"
+              project_id:
+                type: string
+                example: "Field not unique"
 
 get:
   tags:
@@ -117,6 +113,8 @@ get:
                   properties:
                     $oid:
                       type: string
+                project_id:
+                  type: string
             example:
               - _id:
                   $oid: "605e4e9c2226f89fb151d0a1"
@@ -127,6 +125,7 @@ get:
                     amount: 200
                 creator_id:
                   $oid: "6059234f9885cb36c1964f52"
+                project_id: "project-id-123"
 
               - _id:
                   $oid: "605926640605c11c5b48bcdd"
@@ -139,3 +138,4 @@ get:
                     amount: 100
                 creator_id:
                   $oid: "6059234f9885cb36c1964f52"
+                project_id: "project-id-456"

--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -12,6 +12,8 @@ tags:
     description: Endpoints regarding user management
   - name: projects
     description: Endpoints regarding projects
+  - name: hardware
+    description: Endpoints regarding hardware
 
 paths:
   /users/login:
@@ -24,3 +26,9 @@ paths:
     $ref: ./EndpointDocumentation/Projects/project_w_id.yml
   /projects/{project_oid}:
     $ref: ./EndpointDocumentation/Projects/project_w_oid.yml
+  /hardware/:
+    $ref: ./EndpointDocumentation/Hardware/hardware.yml
+  /hardware/{projectID}:
+    $ref: ./EndpointDocumentation/Hardware/hardware_p_id.yml
+  /hardware/{hardwareID}:
+    $ref: ./EndpointDocumentation/Hardware/hardware_hw_id.yml

--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -20,8 +20,7 @@ paths:
     $ref: ./EndpointDocumentation/Users/register.yml
   /projects/:
     $ref: ./EndpointDocumentation/Projects/projects.yml
-  /projects/{projectID}:
+  /projects/{project_id}:
     $ref: ./EndpointDocumentation/Projects/project_w_id.yml
-
-
-
+  /projects/{project_oid}:
+    $ref: ./EndpointDocumentation/Projects/project_w_oid.yml


### PR DESCRIPTION
### Problem
The hardware model does not have a name field, so differentiating between the hardware set will be difficult.

### Solution
Add a unique name `StringField` to the hardware models.

### Testing
Tested with Postman to see if the name field is working as intended.

Closes #110