### PR TITLE
User Documentation

### DIFF
--- a/client/src/components/Information.css
+++ b/client/src/components/Information.css
@@ -1,0 +1,18 @@
+a {
+    text-decoration: none;
+    color: blue;
+}
+
+.info-modal {
+    border-radius: 1.4em;
+    background-color: white;
+    overflow-y: scroll;
+    width: 80vw;
+    height: 80vh;
+    margin: 10vh 10vw 10vh 10vw;
+    padding: 3em;
+}
+
+#text-body {
+    margin-bottom: 1em;
+}

--- a/client/src/components/Information.js
+++ b/client/src/components/Information.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+export default function Information() {
+  return (
+    <div>
+      Hello World!
+    </div>
+  )
+}

--- a/client/src/components/Information.js
+++ b/client/src/components/Information.js
@@ -1,10 +1,31 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
+import './Information.css';
 
 export default function Information() {
   return (
-    <div>
-      Hello World!
+    <div class="info-modal">
+      <Typography variant="h2" style={{"text-align": "center", "padding-bottom": "0.4em"}}>Help Guide</Typography>
+      
+      {/* Dashboard */}
+      <Typography variant="h4">Dashboard</Typography>
+      <Typography id="text-body" variant="h6">After entering the app you'll land on the dashboard. Here you will find a navigation menu on the left that can take you to our different pages (resources, datasets, etc.) and cards on the page that show stats about your projects. From here you can switch to a specific project using the dropdown menu.</Typography>
+
+      {/* Resources */}
+      <Typography variant="h4">Resources</Typography>
+      <Typography id="text-body" variant="h6">The resources page shows you all of the different hardware sets' capacities and availabilities. It also lets you check in or check out resources. Before checking in or checking out any resources, make sure to go to the projects page and select a project.</Typography>
+      
+      {/* Projects */}
+      <Typography variant="h4">Projects</Typography>
+      <Typography id="text-body" variant="h6">Once you've switched to a particular project, you're able to view the relevant information for it on the project page. On that page, you're also able to join a new project if you have the corresponding project ID or create a new project. There's a button to switch to a different project on this page as well.</Typography>
+      
+      {/* Billing */}
+      <Typography variant="h4">Billing</Typography>
+      <Typography id="text-body" variant="h6">The billing page shows you the costs associated with your projects. It's calculated by multiplying each hardware set's cost per hour by the number of hours the hardware has been checked out.</Typography>
+      
+      {/* Datasets */}
+      <Typography variant="h4">Datasets</Typography>
+      <Typography id="text-body" variant="h6">The datasets page has all of the datasets from <a href="https://physionet.org/" target="_blank">PhysioNet</a> and clicking one of the links will download the ZIP file for the corresponding dataset.</Typography>
     </div>
   )
 }

--- a/client/src/components/TopAndSideBar.js
+++ b/client/src/components/TopAndSideBar.js
@@ -18,13 +18,16 @@ import PropTypes from 'prop-types';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
+import Modal from '@material-ui/core/Modal';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import DnsIcon from '@material-ui/icons/Dns';
 import DynamicFeedIcon from '@material-ui/icons/DynamicFeed';
 import CreditCardIcon from '@material-ui/icons/CreditCard';
 import CloudDownloadIcon from '@material-ui/icons/CloudDownload';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import InfoIcon from '@material-ui/icons/Info';
 import { AuthContext } from './AuthContext';
+import Information from './Information';
 import { Link } from 'react-router-dom';
 
 const mainListItems = (
@@ -119,6 +122,13 @@ export function TopAndSideBar(props) {
     setOpen(false);
   };
 
+  const [openInfo, setOpenInfo] = React.useState(false);
+  const handleOpenInfo = () => {
+    setOpenInfo(true);
+  };
+  const handleCloseInfo = () => {
+    setOpenInfo(false);
+  };
 
   const { state, dispatch } = React.useContext(AuthContext);
 
@@ -147,7 +157,20 @@ export function TopAndSideBar(props) {
             className={classes.button}
             endIcon={<AccountCircleIcon />}
             >
-            Welcome, {localStorage.getItem("user").replace(/['"]+/g, '')} </Button>
+            {localStorage.getItem("user") ? localStorage.getItem("user").replace(/['"]+/g, '') : "Welcome back!"} </Button>
+          <Button 
+            type="button" 
+            onClick={handleOpenInfo}
+            endIcon={<InfoIcon />}>
+          </Button>
+          <Modal
+            open={openInfo}
+            onClose={handleCloseInfo}
+            aria-labelledby="simple-modal-title"
+            aria-describedby="simple-modal-description"
+          >
+            <Information />
+          </Modal>
         </Toolbar>
       </AppBar>
       <Drawer

--- a/client/src/components/TopAndSideBar.js
+++ b/client/src/components/TopAndSideBar.js
@@ -152,17 +152,10 @@ export function TopAndSideBar(props) {
           <Typography component="h1" variant="h6" color="inherit" noWrap className={classes.title}>
             {(state.projectID !== null && (state.projectID !== 'undefined' || state.projectID !== 'null')) ? `ProjectID: ${state.projectID.replace(/['"]+/g, '')}` : 'No Project Selected'}
           </Typography>
-          <Button
-            color="inherit"
-            className={classes.button}
-            endIcon={<AccountCircleIcon />}
-            >
-            {localStorage.getItem("user") ? localStorage.getItem("user").replace(/['"]+/g, '') : "Welcome back!"} </Button>
           <Button 
-            type="button" 
+            style={{"color": "white", "margin-right": "1.4em"}}
             onClick={handleOpenInfo}
-            endIcon={<InfoIcon />}>
-          </Button>
+            endIcon={<InfoIcon />}>Help</Button>
           <Modal
             open={openInfo}
             onClose={handleCloseInfo}
@@ -171,6 +164,12 @@ export function TopAndSideBar(props) {
           >
             <Information />
           </Modal>
+          <Button
+            color="inherit"
+            className={classes.button}
+            endIcon={<AccountCircleIcon/>}
+            onClick={() => {window.location.assign("/")}}>
+            {localStorage.getItem("user") ? localStorage.getItem("user").replace(/['"]+/g, '') : "Welcome back!"} </Button>
         </Toolbar>
       </AppBar>
       <Drawer


### PR DESCRIPTION
### Problem
Users had no way of getting help if they got stuck. We have written documentation but it was not accessible from the website.

### Solution
Use a Material UI `Modal` that opens when a help button is clicked on the nav bar. The modal contains documentation displayed with Material UI `Typography` which matches our Markdown documentation. The modal is of variable width and height based on browser size.

### Testing
I made sure the modal was able to be opened from every page. I also ensured that the modal size is responsive based on window size and that the text is easily readable.

### Notes
This should satisfy the documentation requirement for Checkpoint 3 and we can show this during the demo. This PR also fixes a bug with the welcome message being null when a user was already logged in.

Closes #133 