### PR TITLE
Add Hardware Names

### DIFF
--- a/server/api/routes/hardware.py
+++ b/server/api/routes/hardware.py
@@ -137,6 +137,7 @@ def hardware_checkout(id):
             if not found:
                 project_hardware.append({
                     "_id": id,
+                    "name": hardware_set["name"],
                     "amount": req["amount"],
                     "cost": 0,
                     "checkout_time": datetime.now()

--- a/swagger/EndpointDocumentation/Projects/project_w_id.yml
+++ b/swagger/EndpointDocumentation/Projects/project_w_id.yml
@@ -38,10 +38,14 @@ get:
                     properties:
                       _id:
                         type: string
+                      name:
+                        type: string
                       amount:
                         type: integer
                       cost:
                         type: number
+                      checkout_time:
+                        type: object
                 creator_id:
                   type: object
                   properties:
@@ -56,8 +60,11 @@ get:
               description: "Project 1 Description"
               hardware:
                 - _id: "605e4e9c2226f89fb151d0a1"
+                  name: "Hardware 1"
                   amount: 200
                   cost: 100.52
+                  checkout_time: 
+                    $date: 1620081706990
               creator_id:
                 $oid: "6059234f9885cb36c1964f52"
               project_id: "project-id-123"

--- a/swagger/EndpointDocumentation/Projects/projects.yml
+++ b/swagger/EndpointDocumentation/Projects/projects.yml
@@ -106,10 +106,14 @@ get:
                     properties:
                       _id:
                         type: string
+                      name:
+                        type: string
                       amount:
                         type: integer
                       cost:
                         type: number
+                      checkout_time:
+                        type: object
                 creator_id:
                   type: object
                   properties:
@@ -124,8 +128,11 @@ get:
                 description: "Project 1 Description"
                 hardware:
                   - _id: "605e4e9c2226f89fb151d0a1"
+                    name: "Hardware 1"
                     amount: 200
                     cost: 100.52
+                    checkout_time: 
+                      $date: 1620081706990
                 creator_id:
                   $oid: "6059234f9885cb36c1964f52"
                 project_id: "project-id-123"
@@ -136,11 +143,17 @@ get:
                 description: "Project 2 Description"
                 hardware:
                   - _id: "605e4e9c2226f89fb151d0a1"
+                    name: "Hardware 1"
                     amount: 200
                     cost: 50.24
+                    checkout_time: 
+                      $date: 1620081706990
                   - _id: "605e4e9c2226f89fb151d0a2"
+                    name: "Hardware 2"
                     amount: 100
                     cost: 10.20
+                    checkout_time: 
+                      $date: 1620081706112
                 creator_id:
                   $oid: "6059234f9885cb36c1964f52"
                 project_id: "project-id-456"


### PR DESCRIPTION
### Problem
The names of a hardware set is not associated with the hardware list of a project object.

### Solution
Add a `name` entry for every hardware associated with the project. This is done during checkout. Updated swagger documentation to reflect this change.

### Testing
Used Postman to test that the `name` is being properly set.

Closes #138